### PR TITLE
Merge pull request #146 from BlackPoker/145-bug-コアフローの誘発チェックから遷移する先が不明確

### DIFF
--- a/source/core/coreflow.puml
+++ b/source/core/coreflow.puml
@@ -26,6 +26,7 @@ else (No)
                 stop
             endif
             :[6]誘発チェック;
+            :[2]ターンプレイヤーにチャンスを移動;
         else (No)
         endif
     else (No)


### PR DESCRIPTION
145 bug コアフローの誘発チェックから遷移する先が不明確

## チケットへのリンク

#145

## やったこと

* [2]ターンプレイヤーにチャンスを移動を追加

