### PR TITLE
[BUG] html側のumlが表示されない

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,10 +30,10 @@ RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/l
 # RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
 
 # install plantuml
-ENV PLANTUML_VERSION 1.2023.0
+ENV PLANTUML_VERSION 1.2024.3
 RUN sudo apt update
 RUN sudo apt-get install -y default-jdk graphviz fonts-ipafont fonts-ipaexfont
-RUN curl -L https://sourceforge.net/projects/plantuml/files/plantuml.${PLANTUML_VERSION}.jar/download -o ./plantuml.jar 
+RUN curl -L https://github.com/plantuml/plantuml/releases/download/v${PLANTUML_VERSION}/plantuml-${PLANTUML_VERSION}.jar -o ./plantuml.jar 
 RUN sudo cp plantuml.jar /usr/local/bin
 RUN echo "#!/bin/bash\nexport LANG=ja_JP.UTF-8;\n/usr/bin/java -Djava.io.tmpdir=/var/tmp -Djava.awt.headless=true -jar /usr/local/bin/plantuml.jar  -charset UTF-8 \${@}" > /usr/bin/plantuml
 RUN sudo chmod 0755 /usr/bin/plantuml

--- a/base-docker/Dockerfile
+++ b/base-docker/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache ttf-droid-nonlatin
 RUN apk add --no-cache curl
 RUN apk add --no-cache openjdk11
 RUN mkdir -p /app
-RUN curl -L https://sourceforge.net/projects/plantuml/files/plantuml.${PLANTUML_VERSION}.jar/download -o /app/plantuml.jar 
+RUN curl -L https://github.com/plantuml/plantuml/releases/download/v${PLANTUML_VERSION}/plantuml-${PLANTUML_VERSION}.jar -o /app/plantuml.jar
 RUN apk del curl
 RUN cp /app/plantuml.jar /usr/local/bin
 RUN echo -e "#!/bin/sh\nexport LANG=ja_JP.UTF-8;\n/usr/bin/java -Djava.io.tmpdir=/var/tmp -Djava.awt.headless=true -jar /usr/local/bin/plantuml.jar  -charset UTF-8 \${@}" > /usr/bin/plantuml


### PR DESCRIPTION
Fixes #161

plantumlのjarをダウンロード先をsourceforgeからgithubに変更

## チケットへのリンク

* #161

## やったこと

* baseにしていたdockreイメージ似て、plantumlのダウンロードに失敗していたので、修正

## できるようになること（ユーザ目線）

* UMLが表示されるようになった

## できなくなること（ユーザ目線）

* なし
