### PR TITLE
[BUG] 追撃は速攻魔法ではなくて通常魔法

### DIFF
--- a/tools/actionlist/original/act-frame.yaml
+++ b/tools/actionlist/original/act-frame.yaml
@@ -399,7 +399,7 @@ actList:
         ・エクストラ
       actName: 追撃
       actId: pursuit
-      actType: 速攻魔法
+      actType: 通常魔法
       actTrigger: 直接
       actSpeed: 通常
       actTime: メイン


### PR DESCRIPTION
Fixes #372

## チケットへのリンク

* #372

## やったこと

* このプルリクで何をしたのか？

## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
